### PR TITLE
Attempt to fix SendTarget addon

### DIFF
--- a/SendTarget/SendTarget.lua
+++ b/SendTarget/SendTarget.lua
@@ -31,15 +31,14 @@ _addon.version = '1.0.0.0';
 _addon.author = 'Ivaar';
 
 require 'common'
-require 'events'
-target = require('ffxi.target');
+target = require('ffxi.targets');
 
 ---------------------------------------------------------------------------------------------------
 -- func: command
 -- desc: Called when our addon receives a command.
 ---------------------------------------------------------------------------------------------------
 ashita.register_event('command', function(cmd, nType)
-    local args = cmd:GetArgs();
+    local args = cmd:args();
     if (args[1] ~= '/sendtarget' and args[1] ~= '/st') then
         return false;
     end
@@ -60,10 +59,13 @@ ashita.register_event('command', function(cmd, nType)
     if (args[4]:startswith('/') == false) then
         args[4] = '/' .. args[4];
     end
-    
-    local entity = get_target('lastst');
-    if (entity ~= nil) then
-        local str = '/servo sendto '.. table.concat(args,' ',3) ..' '.. entity.ServerID;
+	
+	local target = AshitaCore:GetDataManager():GetTarget();
+    local tid = target:GetSubTargetServerId();
+    local tidx = target:GetSubTargetIndex();
+	
+    if (target ~= nil) then
+        local str = '/ms sendto '.. table.concat(args,' ',3) ..' '.. tid .. ' ' .. tidx;
         AshitaCore:GetChatManager():QueueCommand(str, -1);
     else
         print(string.format('Could not find last sub-target. No action performed...'));

--- a/SendTarget/SendTarget.lua
+++ b/SendTarget/SendTarget.lua
@@ -60,12 +60,10 @@ ashita.register_event('command', function(cmd, nType)
         args[4] = '/' .. args[4];
     end
 	
-	local target = AshitaCore:GetDataManager():GetTarget();
-    local tid = target:GetSubTargetServerId();
-    local tidx = target:GetSubTargetIndex();
+    local target = AshitaCore:GetDataManager():GetTarget():GetSubTargetServerId()
 	
     if (target ~= nil) then
-        local str = '/ms sendto '.. table.concat(args,' ',3) ..' '.. tid .. ' ' .. tidx;
+        local str = '/ms sendto '.. table.concat(args,' ',3) ..' '.. target;
         AshitaCore:GetChatManager():QueueCommand(str, -1);
     else
         print(string.format('Could not find last sub-target. No action performed...'));


### PR DESCRIPTION
I'm definitely no coder, and have zero experience with LUA and Ashita libraries but this does appear to work now using these changes. I swapped it to using /ms instead of /servo and then various changes to work with v3 Ashita.

I can only seem to get this to work while outside of combat, though. I'm really after finding a way to be able to send a dualbox my main's subtarget id while in combat, but if I'm engaged in combat then my dualbox doesn't seem to be getting it's target.