### PR TITLE
Fixes crash with incoming packet

### DIFF
--- a/Skillchains/Skillchains.lua
+++ b/Skillchains/Skillchains.lua
@@ -316,7 +316,7 @@ function chain_buff(t)
     return t[163] and check_buff(t, 163);
 end
 
-ashita.register_event('incoming_packet', function(id, size, data)
+ashita.register_event('incoming_packet', function(id, size, data, modified, blocked)
     if id == 0x0A then
         reset()
     elseif id == 0x28 then


### PR DESCRIPTION
Incoming packet has more parameters and does not have an overload for only 2.

This changes the registration pointer to use the correct number of parameters.